### PR TITLE
model actions as enums

### DIFF
--- a/examples/src/main/scala/examples/example1.scala
+++ b/examples/src/main/scala/examples/example1.scala
@@ -69,20 +69,11 @@ case class State[F[_]](
     scatterPlot: scatter.State = scatter.State()
 )
 
-sealed trait Action[F[_]]
-
-object Action:
-
-  case class Noop[F[_]]() extends Action[F]
-
-  case class SetCanvas[F[_]](canvas: fs2.dom.HtmlCanvasElement[F])
-      extends Action[F]
-
-  case class SetScatterPlotData[F[_]](
-      traces: List[ScatterPlot.Trace]
-  ) extends Action[F]
-
-  case class RandomizeData[F[_]]() extends Action[F]
+enum Action[F[_]]:
+  case Noop()
+  case SetCanvas(canvas: fs2.dom.HtmlCanvasElement[F])
+  case SetScatterPlotData(traces: List[ScatterPlot.Trace])
+  case RandomizeData()
 
 trait View[F[_]] extends Buttons[State[F], Action[F]]:
   dsl: ff4s.Dsl[State[F], Action[F]] =>

--- a/examples/src/main/scala/examples/example2.scala
+++ b/examples/src/main/scala/examples/example2.scala
@@ -220,11 +220,11 @@ case class State[F[_]](
 )
 
 enum Action[F[_]]:
-  case Noop() 
+  case Noop()
   case SetCanvas(canvas: fs2.dom.HtmlCanvasElement[F])
-  case SetData(traces: Chart.Trace) 
+  case SetData(traces: Chart.Trace)
   case RandomizeData()
-  case UpdatePoint(old: Point, upd: Point) 
+  case UpdatePoint(old: Point, upd: Point)
 
 trait View[F[_]] extends Buttons[State[F], Action[F]]:
   dsl: ff4s.Dsl[State[F], Action[F]] =>

--- a/examples/src/main/scala/examples/example2.scala
+++ b/examples/src/main/scala/examples/example2.scala
@@ -219,20 +219,12 @@ case class State[F[_]](
     chart: Chart.State = Chart.State()
 )
 
-sealed trait Action[F[_]]
-
-object Action:
-
-  case class Noop[F[_]]() extends Action[F]
-
-  case class SetCanvas[F[_]](canvas: fs2.dom.HtmlCanvasElement[F])
-      extends Action[F]
-
-  case class SetData[F[_]](traces: Chart.Trace) extends Action[F]
-
-  case class RandomizeData[F[_]]() extends Action[F]
-
-  case class UpdatePoint[F[_]](old: Point, upd: Point) extends Action[F]
+enum Action[F[_]]:
+  case Noop() 
+  case SetCanvas(canvas: fs2.dom.HtmlCanvasElement[F])
+  case SetData(traces: Chart.Trace) 
+  case RandomizeData()
+  case UpdatePoint(old: Point, upd: Point) 
 
 trait View[F[_]] extends Buttons[State[F], Action[F]]:
   dsl: ff4s.Dsl[State[F], Action[F]] =>


### PR DESCRIPTION
I think it's nicer to model `Action`s as `enum`s, a bit less code and more compact. 